### PR TITLE
docs(changelog): added more changelog content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v0.2.0 (2025-06-29)
 
-### Feat
+### Features
 
-- **project**: establish foundational structure and CI/CD workflow
-- **core**: establish data models and development workflow
+- **Core**: Established foundational data models (`Character`, `Area`, `Contract`) using Pydantic for runtime validation.
+- **UI**: Added the `AlarmBar` component to display system alert levels.
+- **CI/CD**: Implemented a full CI/CD pipeline with GitHub Actions for automated testing on pull requests and automated releases on merges to main.
+- **Tooling**: Integrated `commitizen` for conventional commits and `pre-commit` for automated code quality checks (linting, formatting, testing).
+
+### Bug Fixes
+
+- **CI/CD**: Corrected the release workflow to ensure `commitizen` could find the project version and that the GitHub Actions bot had the correct permissions to push release commits and tags.
+- **Linting**: Fixed various linting issues across the codebase.
+
+### Documentation
+
+- Created initial project documentation, including `README.md`, `architecture.md`, and `porting_items.md`.
+- Updated `README.md` with detailed setup, development, and release instructions.
+
+### Testing & Refactoring
+
+- Established the initial test suite using `pytest` and achieved 100% test coverage.
+- Refactored asset loading to dynamically load sprites from spritesheets and reorganized the asset directory structure.


### PR DESCRIPTION
the initial cz bump generated a changelog based on only the most recent commit. since this was the first time the bump with changelog was run, it should include information from the earlier commits.