### PR TITLE
feat(game): Add quit key and improve test suite robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ cz commit
 
 `commitizen` will prompt you through the process of creating a great commit message. The `pre-commit` hook will ensure that all commits adhere to this standard.
 
+### Development Mode
+
+To enable development mode for rapid prototyping (e.g., giving the character extra starting credits), you can set an environment variable before running the game:
+
+```bash
+export DECKER_DEV_ENABLED=1
+decker
+```
+
+This allows for temporary, config-driven changes without affecting test coverage.
+
 #### What if a pre-commit hook fails?
 
 If a hook fails (e.g., due to a linting error or a failing test), the commit will be aborted. However, your carefully crafted commit message is not lost.

--- a/docs/architecture/ddd_implementation_guide.md
+++ b/docs/architecture/ddd_implementation_guide.md
@@ -119,3 +119,11 @@ Our event-driven architecture provides the foundation for a powerful pattern cal
 Instead of storing the *current state* of our aggregates, Event Sourcing involves persisting the full, chronological log of domain events that have occurred. The current state is then derived by replaying these events.
 
 For a detailed explanation of this concept and how our current features relate to it, see the Event Sourcing Guide.
+
+## 7. Development & Debugging Concerns
+
+To facilitate rapid prototyping and debugging without polluting the core domain or application layers, we use a configuration-driven "dev mode".
+
+-   **Strategy:** Development-specific logic (e.g., verbose input logging, granting extra starting resources) is placed within the `presentation` or `main` composition root.
+-   **Control:** This logic is wrapped in a conditional check against `DEV_SETTINGS.enabled`, which is controlled by an environment variable.
+-   **Benefit:** This approach keeps our core layers clean and testable, while allowing for flexible, temporary changes during development.

--- a/docs/development/prompt_log.md
+++ b/docs/development/prompt_log.md
@@ -133,3 +133,75 @@ This document tracks the prompts and outcomes during the major refactoring to a 
 
 44. **Prompt:** "FAILED tests/presentation/test_game.py::test_game_initialization - AssertionError: assert False (re-run)"
     -   **Outcome:** Resolved a recurring cryptic test failure by patching `pygame.transform.scale` in the shared `mocked_game_instance` fixture. This prevents a hidden exception during `Game` initialization in the test environment.
+
+45. **Prompt:** "still having the same issue: ... AssertionError: assert False"
+    -   **Outcome:** Resolved the final cryptic `assert False` error by refactoring the `test_game.py` fixture to be more explicit. The test now verifies dependency injection using an identity check (`is`) instead of a problematic type check (`isinstance`) on a mock object.
+
+46. **Prompt:** "FAILED tests/presentation/test_game.py::test_game_initialization - AssertionError: assert False"
+    -   **Outcome:** Fixed a failing test by removing a redundant and incorrect `isinstance` check on a mock object. Also corrected a typo in another test that was incorrectly accessing a method on a mock service.
+
+47. **Prompt:** "Refactor `AlarmBar` and `HealthBar` to inherit from a common `PercentageBar` base class to reduce code duplication."
+    -   **Outcome:** Created a new `PercentageBar` base class to contain shared drawing logic. Refactored `AlarmBar` and `HealthBar` to inherit from it, simplifying their code. Updated and added tests to ensure full coverage of the new structure.
+
+48. **Prompt:** "FAILED tests/presentation/test_game.py... TypeError: AlarmBar.__init__() takes 4 positional arguments but 5 were given"
+    -   **Outcome:** Fixed a `TypeError` by updating the `AlarmBar` instantiation in the `Game` class to match the component's refactored constructor signature.
+
+49. **Prompt:** "Now that the `PercentageBar` is done, let's update the `Game` class to use the `HealthBar`."
+    -   **Outcome:** Added a `get_player_status` query method to the `PlayerService`. Integrated the `HealthBar` component into the `Game` class, which now calls the service to update the bar's state each frame. Added and updated tests to ensure coverage.
+
+50. **Prompt:** "test_game.py has some missing coverage and test failures."
+    -   **Outcome:** Fixed `TypeError` in `test_game.py` by configuring mock services to return valid DTOs. Added new tests to cover edge cases (e.g., no schematics available, player not found) and improved existing tests to check console output, resolving all coverage gaps.
+
+51. **Prompt:** "let's try a real local run... ModuleNotFoundError... Can we make it config-driven so we don't have to worry about test coverage...?"
+    -   **Outcome:** Fixed the `ModuleNotFoundError` by correcting the project's entry point script in `pyproject.toml`. Implemented a config-driven "dev mode" using an environment variable to allow for rapid prototyping without impacting tests.
+
+52. **Prompt:** "decker... pygame.error: font not initialized"
+    -   **Outcome:** Fixed a runtime error by adding `pygame.init()` to the application's main entry point (`main.py`), ensuring the framework is initialized before any UI components are created.
+
+53. **Prompt:** "everything is running now. How can I test my Views and UI elements? Let's start with something simple first."
+    -   **Outcome:** Provided a step-by-step guide for manually testing the `BuildView`. Refactored the `Game` class to use the `MessageView` for user feedback instead of printing to the console, and updated tests accordingly.
+
+54. **Prompt:** "I see b bring up the build dialog (open and close). But the font is hard to read against the grey background."
+    -   **Outcome:** Improved UI readability by adding a new `dark_font_color` to the settings. Updated `BuildView` and `MessageView` to use this new color, providing better contrast on light backgrounds without affecting text on dark backgrounds.
+
+55. **Prompt:** "I clicked it a few times... ValueError: Insufficient credits... We shouldn't crash... I'm not seeing the ItemCrafted event in stdout."
+    -   **Outcome:** Fixed the crash by having the `CraftingService` catch the domain's `ValueError` and re-raise it as a specific `InsufficientResourcesError`. Added a new event handler to log `ItemCrafted` events to the console.
+
+56. **Prompt:** "the separate log functions for each event will quickly become a maintenance nightmare. Can we consolidate...?"
+    -   **Outcome:** Refactored the logging system using a Strategy pattern. Created a `LoggingService` and `LogWriter` protocol. Replaced specific event loggers with a generic, reusable event handler factory, making the system more scalable and maintainable.
+
+57. **Prompt:** "FAILED tests/application/test_crafting_service.py... FAILED tests/application/test_event_handlers.py..."
+    -   **Outcome:** Fixed two test failures. Updated a test to expect the correct application-level exception (`InsufficientResourcesError`). Corrected another test to properly inspect the positional and keyword arguments passed to a mocked method.
+
+58. **Prompt:** "We're missing some test coverage: game.py... logging_service.py..."
+    -   **Outcome:** Added new tests to cover edge cases and untested public methods, including the scenario where no icons are loaded and the `LoggingService.register` method, bringing test coverage back to 100%.
+
+59. **Prompt:** "Add q to quit the game... should keypresses be logged?"
+    -   **Outcome:** Added 'q' as a quit key. Implemented a dev-mode-only input logger by injecting the `LoggingService` into the `Game` class, keeping domain and input logging separate. Updated all relevant tests.
+
+59. **Prompt:** "coverage is still missing for line 10 (logging_service) and 83-92 (game)"
+    -   **Outcome:** Resolved final coverage gaps by adding a `# pragma: no cover` to a protocol definition and adding new, focused tests for an edge case in `_load_assets` and a public method in `LoggingService`.
+
+60. **Prompt:** "game is still lacking coverage for line 83-92"
+    -   **Outcome:** Fixed a critical issue in the test suite where a test function was duplicated, which likely caused inaccurate coverage reports. Also added a `pragma: no cover` to a protocol definition to resolve the final remaining coverage gap.
+
+61. **Prompt:** "Game is still having an issue. Perhaps refactoring to move the scaling logic to a function might make it easier, and reusable for other components."
+    -   **Outcome:** Refactored the icon scaling logic from the `Game` class into a new, reusable `scale_icons` utility function. Added dedicated tests for the new utility, resolving the final test coverage gap in `game.py`.
+
+62. **Prompt:** "E           AssertionError: expected call not found."
+    -   **Outcome:** Fixed a failing test by correctly configuring a mock's return value. The mock for the `scale_icons` utility was updated to return an empty list, matching the expected behavior of the real function.
+
+63. **Prompt:** "E           AssertionError: assert 0 == 1"
+    -   **Outcome:** Fixed a failing test by configuring a mock for the `scale_icons` utility to return a list with one item, ensuring the test environment accurately reflected the expected data flow.
+
+64. **Prompt:** "mypy... error: Only concrete class can be given where 'type[Event]' is expected"
+    -   **Outcome:** Resolved a `mypy` error by adding a `# type: ignore[type-abstract]` comment to a decorator. This acknowledges the intentional use of an abstract `Protocol` type for semantic purposes, which the type checker correctly flags as an issue.
+
+65. **Prompt:** "decker runs, so let's get documentation updated with the new efficiencies and improvements we've made. I would also like help crafting a cz commit message"
+    -   **Outcome:** Crafted a comprehensive commit message summarizing recent features and fixes. Updated the `ddd_implementation_guide.md` to include a new section on handling development-specific features in a clean, config-driven way.
+
+66. **Prompt:** "missing test coverage, presumably from the refactorings we've done..."
+    -   **Outcome:** Added new tests to cover the "dev mode" logic in `main.py` and all branches of the `get_and_ensure_rect` utility function, bringing test coverage back to 100%.
+
+67. **Prompt:** ""size" is not a known attribute of "None""
+    -   **Outcome:** Resolved a `Pylance` static analysis error in `test_utils.py` by using a function's correctly-typed return value in an assertion, rather than relying on a dynamically-added attribute that the type checker could not infer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 ]
 
 [project.scripts]
-decker = "decker_pygame.main:main"
+decker = "decker_pygame.presentation.main:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/decker_pygame/application/crafting_service.py
+++ b/src/decker_pygame/application/crafting_service.py
@@ -79,7 +79,11 @@ class CraftingService:
             ) from None
 
         # Execute the domain logic
-        character.craft(schematic_to_use)
+        try:
+            character.craft(schematic_to_use)
+        except ValueError as e:
+            # Translate domain error into application-specific error
+            raise InsufficientResourcesError(str(e)) from e
 
         # Persist the new state
         self.character_repo.save(character)

--- a/src/decker_pygame/application/logging_service.py
+++ b/src/decker_pygame/application/logging_service.py
@@ -1,0 +1,34 @@
+import json
+from typing import Any, Protocol
+
+
+class LogWriter(Protocol):
+    """A protocol for log writing strategies."""
+
+    def write(self, message: str, data: dict[str, Any]) -> None:
+        """Writes a log entry."""
+        ...  # pragma: no cover
+
+
+class ConsoleLogWriter:
+    """A LogWriter that prints formatted JSON to the console."""
+
+    def write(self, message: str, data: dict[str, Any]) -> None:
+        log_entry = {"message": message, "data": data}
+        print(f"LOG: {json.dumps(log_entry, indent=2)}")
+
+
+class LoggingService:
+    """A service for dispatching log messages to various writers."""
+
+    def __init__(self, writers: list[LogWriter] | None = None) -> None:
+        self._writers = writers or []
+
+    def register(self, writer: LogWriter) -> None:
+        """Register a new log writer."""
+        self._writers.append(writer)
+
+    def log(self, message: str, data: dict[str, Any]) -> None:
+        """Send a log message to all registered writers."""
+        for writer in self._writers:
+            writer.write(message, data)

--- a/src/decker_pygame/application/player_service.py
+++ b/src/decker_pygame/application/player_service.py
@@ -1,6 +1,7 @@
 # player_service.py
 
 import uuid
+from dataclasses import dataclass
 
 from decker_pygame.application.event_dispatcher import EventDispatcher
 from decker_pygame.domain.ids import PlayerId
@@ -12,6 +13,14 @@ class PlayerCreationPreconditionError(Exception):
     """Custom exception raised when preconditions for creating a player are not met."""
 
     pass
+
+
+@dataclass(frozen=True)
+class PlayerStatusDTO:
+    """Data Transfer Object for player status to be displayed in the UI."""
+
+    current_health: int
+    max_health: int
 
 
 class PlayerService:
@@ -57,3 +66,20 @@ class PlayerService:
         player.clear_events()
 
         return PlayerId(player.id)
+
+    def get_player_status(self, player_id: PlayerId) -> PlayerStatusDTO | None:
+        """
+        Retrieves the current status of a player for UI display.
+
+        Args:
+            player_id: The ID of the player to query.
+
+        Returns:
+            A DTO with player status, or None if the player is not found.
+        """
+        player = self.player_repo.get(player_id)
+        if not player:
+            return None
+
+        # Assuming max health is 100 for now, as defined in Player.create
+        return PlayerStatusDTO(current_health=player.health, max_health=100)

--- a/src/decker_pygame/presentation/components/alarm_bar.py
+++ b/src/decker_pygame/presentation/components/alarm_bar.py
@@ -1,38 +1,29 @@
-import pygame
-
+from decker_pygame.presentation.components.percentage_bar import PercentageBar
 from decker_pygame.settings import ALARM
 
 
-class AlarmBar(pygame.sprite.Sprite):
+class AlarmBar(PercentageBar):
     """
     A sprite component that displays the system alert level as a percentage bar.
     The bar's color changes as the alert level increases.
     """
 
-    image: pygame.Surface
-    rect: pygame.Rect
-    alarm_level: int
-    color: pygame.Color
-
-    def __init__(self, x: int, y: int, width: int, height: int) -> None:
+    def __init__(self, position: tuple[int, int], width: int, height: int) -> None:
         """
         Initialize the AlarmBar.
 
         Args:
-            position: The (x, y) position of the top-left corner of the bar.
+            position: The (x, y) position of the top-left corner.
             width: The maximum width of the bar.
             height: The height of the bar.
         """
-        super().__init__()
-
-        self.width = width
-        self.height = height
-        self.image = pygame.Surface([self.width, self.height], pygame.SRCALPHA)
-        self.rect = self.image.get_rect(topleft=(x, y))
-
-        self.alarm_level = 0
-        self.color = ALARM.colors[0]
-
+        super().__init__(
+            position=position,
+            width=width,
+            height=height,
+            initial_color=ALARM.colors[0],
+        )
+        self._percentage = 0.0  # Alarm starts at 0
         self.update()  # Initial draw
 
     def update_state(self, alert_level: int, is_crashing: bool) -> None:
@@ -43,22 +34,14 @@ class AlarmBar(pygame.sprite.Sprite):
             alert_level: The new alarm level (0-100).
             is_crashing: Whether the system is crashing.
         """
-        self.alarm_level = max(0, min(alert_level, 100))
+        self._percentage = float(max(0, min(alert_level, 100)))
 
         if is_crashing:
-            self.color = ALARM.crash_color
+            self._color = ALARM.crash_color
         else:
             num_colors = len(ALARM.colors)
             if num_colors > 0:
-                index = int((self.alarm_level / 100) * (num_colors - 1))
-                self.color = ALARM.colors[index]
+                index = int((self._percentage / 100) * (num_colors - 1))
+                self._color = ALARM.colors[index]
 
         self.update()
-
-    def update(self) -> None:
-        """Redraws the alarm bar surface based on the current state."""
-        self.image.fill((0, 0, 0, 0))  # Fill with a transparent color
-        current_width = int(self.width * (self.alarm_level / 100))
-        if current_width > 0:
-            bar_rect = pygame.Rect(0, 0, current_width, self.height)
-            pygame.draw.rect(self.image, self.color, bar_rect)

--- a/src/decker_pygame/presentation/components/build_view.py
+++ b/src/decker_pygame/presentation/components/build_view.py
@@ -32,7 +32,7 @@ class BuildView(pygame.sprite.Sprite):
         self._font = pygame.font.Font(
             UI_FONT.default_font_name, UI_FONT.default_font_size
         )
-        self._font_color = UI_FONT.default_font_color
+        self._font_color = UI_FONT.dark_font_color
         self._background_color = UI_FACE
         self._line_height = self._font.get_linesize()
         self._padding = 10

--- a/src/decker_pygame/presentation/components/health_bar.py
+++ b/src/decker_pygame/presentation/components/health_bar.py
@@ -1,59 +1,35 @@
-import pygame
-
+from decker_pygame.presentation.components.percentage_bar import PercentageBar
 from decker_pygame.settings import HEALTH
 
 
-class HealthBar(pygame.sprite.Sprite):
+class HealthBar(PercentageBar):
     """A sprite component that displays a health value as a percentage bar."""
-
-    image: pygame.Surface
-    rect: pygame.Rect
 
     def __init__(self, position: tuple[int, int], width: int, height: int):
         """
         Initialize the HealthBar.
-
-        Args:
-            position: The (x, y) position of the top-left corner.
-            width: The maximum width of the bar.
-            height: The height of the bar.
         """
-        super().__init__()
-        self.width = width
-        self.height = height
-        self.image = pygame.Surface([self.width, self.height], pygame.SRCALPHA)
-        self.rect = self.image.get_rect(topleft=position)
-
-        self._health_percent = 100.0
-        self._color = HEALTH.colors[0][1]
-
+        super().__init__(
+            position=position,
+            width=width,
+            height=height,
+            initial_color=HEALTH.colors[0][1],
+        )
         self.update()
 
     def update_health(self, current: int, maximum: int) -> None:
         """
         Update the health bar's state based on current and max health values.
-
-        Args:
-            current: The current health value.
-            maximum: The maximum possible health value.
         """
-        self._health_percent = (current / maximum) * 100 if maximum > 0 else 0
-        self._health_percent = max(0, min(self._health_percent, 100))
+        self._percentage = (current / maximum) * 100 if maximum > 0 else 0
+        self._percentage = max(0, min(self._percentage, 100))
 
         # Default to the last color in the list (lowest health color) and then
         # find the first threshold that the health is greater than.
         if HEALTH.colors:
             self._color = HEALTH.colors[-1][1]
             for threshold, color in HEALTH.colors:
-                if self._health_percent > threshold:
+                if self._percentage > threshold:
                     self._color = color
                     break
         self.update()
-
-    def update(self) -> None:
-        """Redraws the health bar surface based on the current state."""
-        self.image.fill((0, 0, 0, 0))  # Fill with a transparent color
-        current_width = int(self.width * (self._health_percent / 100))
-        if current_width > 0:
-            bar_rect = pygame.Rect(0, 0, current_width, self.height)
-            pygame.draw.rect(self.image, self._color, bar_rect)

--- a/src/decker_pygame/presentation/components/message_view.py
+++ b/src/decker_pygame/presentation/components/message_view.py
@@ -34,7 +34,7 @@ class MessageView(pygame.sprite.Sprite):
         self.font = pygame.font.Font(
             UI_FONT.default_font_name, UI_FONT.default_font_size
         )
-        self.font_color = UI_FONT.default_font_color
+        self.font_color = UI_FONT.dark_font_color
         self.line_height = self.font.get_linesize()
         self.padding = 5
 

--- a/src/decker_pygame/presentation/components/percentage_bar.py
+++ b/src/decker_pygame/presentation/components/percentage_bar.py
@@ -1,0 +1,38 @@
+import pygame
+
+
+class PercentageBar(pygame.sprite.Sprite):
+    """
+    A base class for UI components that display a value as a
+    horizontal percentage bar.
+    """
+
+    image: pygame.Surface
+    rect: pygame.Rect
+
+    def __init__(
+        self,
+        position: tuple[int, int],
+        width: int,
+        height: int,
+        initial_color: pygame.Color,
+    ) -> None:
+        """
+        Initialize the PercentageBar.
+        """
+        super().__init__()
+        self.width = width
+        self.height = height
+        self.image = pygame.Surface([self.width, self.height], pygame.SRCALPHA)
+        self.rect = self.image.get_rect(topleft=position)
+
+        self._percentage = 100.0
+        self._color = initial_color
+
+    def update(self) -> None:
+        """Redraws the bar surface based on the current percentage and color."""
+        self.image.fill((0, 0, 0, 0))  # Fill with a transparent color
+        current_width = int(self.width * (self._percentage / 100))
+        if current_width > 0:
+            bar_rect = pygame.Rect(0, 0, current_width, self.height)
+            pygame.draw.rect(self.image, self._color, bar_rect)

--- a/src/decker_pygame/presentation/game.py
+++ b/src/decker_pygame/presentation/game.py
@@ -1,15 +1,19 @@
 import pygame
 
 from decker_pygame.application.crafting_service import CraftingError, CraftingService
+from decker_pygame.application.logging_service import LoggingService
 from decker_pygame.application.player_service import PlayerService
 from decker_pygame.domain.ids import CharacterId, PlayerId
 from decker_pygame.presentation.asset_loader import load_spritesheet
 from decker_pygame.presentation.components.active_bar import ActiveBar
 from decker_pygame.presentation.components.alarm_bar import AlarmBar
 from decker_pygame.presentation.components.build_view import BuildView
+from decker_pygame.presentation.components.health_bar import HealthBar
 from decker_pygame.presentation.components.message_view import MessageView
+from decker_pygame.presentation.utils import scale_icons
 from decker_pygame.settings import (
     BLACK,
+    DEV_SETTINGS,
     FPS,
     GFX,
     SCREEN_HEIGHT,
@@ -29,10 +33,12 @@ class Game:
     all_sprites: pygame.sprite.Group[pygame.sprite.Sprite]
     active_bar: ActiveBar
     alarm_bar: AlarmBar
+    health_bar: HealthBar
     player_service: PlayerService
     player_id: PlayerId
     crafting_service: CraftingService
     character_id: CharacterId
+    logging_service: LoggingService
     message_view: MessageView
     build_view: BuildView | None = None
 
@@ -42,6 +48,7 @@ class Game:
         player_id: PlayerId,
         crafting_service: CraftingService,
         character_id: CharacterId,
+        logging_service: LoggingService,
     ) -> None:
         """
         Initialize the Game.
@@ -51,6 +58,7 @@ class Game:
             player_id (PlayerId): The current player's ID.
             crafting_service (CraftingService): Service for crafting operations.
             character_id (CharacterId): The current character's ID.
+            logging_service (LoggingService): Service for logging.
         """
         self.screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
         pygame.display.set_caption(TITLE)
@@ -61,6 +69,7 @@ class Game:
         self.player_id = player_id
         self.crafting_service = crafting_service
         self.character_id = character_id
+        self.logging_service = logging_service
 
         self._load_assets()
 
@@ -81,16 +90,17 @@ class Game:
 
         # Scale the icons up to the size required by the UI components
         target_size = (GFX.active_bar_image_size, GFX.active_bar_image_size)
-        program_icons = [
-            pygame.transform.scale(icon, target_size) for icon in native_icons
-        ]
+        program_icons = scale_icons(native_icons, target_size)
 
         self.active_bar = ActiveBar(position=(0, 0), image_list=program_icons)
         self.all_sprites.add(self.active_bar)
 
         # Position from DeckerSource_1_12/MatrixView.cpp
-        self.alarm_bar = AlarmBar(206, 342, 200, 50)
+        self.alarm_bar = AlarmBar(position=(206, 342), width=200, height=50)
         self.all_sprites.add(self.alarm_bar)
+
+        self.health_bar = HealthBar(position=(10, 342), width=180, height=50)
+        self.all_sprites.add(self.health_bar)
 
         self.message_view = MessageView(
             position=(10, 600), size=(400, 150), background_color=UI_FACE
@@ -111,6 +121,13 @@ class Game:
             if event.type == pygame.KEYDOWN:
                 if event.key == pygame.K_b:
                     self._toggle_build_view()
+                if event.key == pygame.K_q:
+                    self.is_running = False
+
+                if DEV_SETTINGS.enabled:
+                    self.logging_service.log(
+                        "Key Press", {"key": pygame.key.name(event.key)}
+                    )
 
             if self.build_view:
                 self.build_view.handle_event(event)
@@ -138,12 +155,11 @@ class Game:
 
     def _handle_build_click(self, schematic_name: str) -> None:
         """Callback for when a build button is clicked in the BuildView."""
-        print(f"Attempting to build: {schematic_name}")
         try:
             self.crafting_service.craft_item(self.character_id, schematic_name)
-            print(f"Successfully crafted {schematic_name}!")
+            self.show_message(f"Successfully crafted {schematic_name}!")
         except CraftingError as e:
-            print(f"Crafting failed: {e}")
+            self.show_message(f"Crafting failed: {e}")
 
     def show_message(self, text: str) -> None:
         """Displays a message in the message view."""
@@ -156,12 +172,14 @@ class Game:
         Returns:
             None
         """
-        # In the future, we will get player state from the service:
-        # player = self.player_service.get_player(self.player_id)
-        # self.alarm_bar.update_state(player.alert_level, player.is_crashing)
+        player_status = self.player_service.get_player_status(self.player_id)
+        if player_status:
+            self.health_bar.update_health(
+                player_status.current_health, player_status.max_health
+            )
+            # self.alarm_bar.update_state(player.alert_level, player.is_crashing)
 
         self.all_sprites.update()
-        # self.alarm_bar.update_state(0, False) # Example placeholder
 
     def run(self) -> None:
         """

--- a/src/decker_pygame/presentation/utils.py
+++ b/src/decker_pygame/presentation/utils.py
@@ -75,3 +75,19 @@ def render_text_wrapped(
         surface.blit(
             rendered_text, (rect.x + padding, rect.y + padding + i * line_height)
         )
+
+
+def scale_icons(
+    icons: list[pygame.Surface], target_size: tuple[int, int]
+) -> list[pygame.Surface]:
+    """
+    Scales a list of pygame.Surface objects to a target size.
+
+    Args:
+        icons: A list of surfaces to scale.
+        target_size: The (width, height) to scale to.
+
+    Returns:
+        A new list of scaled surfaces.
+    """
+    return [pygame.transform.scale(icon, target_size) for icon in icons]

--- a/src/decker_pygame/settings.py
+++ b/src/decker_pygame/settings.py
@@ -7,6 +7,7 @@ making them easy to adjust.
 
 from pathlib import Path
 
+from pydantic_settings import BaseSettings
 from pygame.color import Color
 
 # --- General ---
@@ -46,6 +47,7 @@ class UiFontSettings:
     default_font_name: str | None = None  # Use pygame default
     default_font_size: int = 18
     default_font_color: Color = Color(200, 200, 200)  # Light grey
+    dark_font_color: Color = Color(20, 20, 20)  # Near-black for light backgrounds
 
 
 UI_FONT = UiFontSettings()
@@ -99,3 +101,16 @@ MAP_VIEW = MapViewSettings()
 
 # --- Gameplay Constants ---
 MAX_ALERT_LEVEL = 100.0
+
+
+# --- Development Settings ---
+class DevSettings(BaseSettings):
+    """Settings for development and debugging, loaded from environment variables."""
+
+    enabled: bool = False
+
+    class Config:
+        env_prefix = "DECKER_DEV_"
+
+
+DEV_SETTINGS = DevSettings()

--- a/tests/application/test_crafting_service.py
+++ b/tests/application/test_crafting_service.py
@@ -6,6 +6,7 @@ import pytest
 from decker_pygame.application.crafting_service import (
     CraftingError,
     CraftingService,
+    InsufficientResourcesError,
     SchematicNotFoundError,
 )
 from decker_pygame.application.event_dispatcher import EventDispatcher
@@ -136,5 +137,5 @@ def test_craft_item_insufficient_credits_in_domain(
     mock_character.craft.side_effect = ValueError("Insufficient credits")
     mock_character_repo.get.return_value = mock_character
 
-    with pytest.raises(ValueError, match="Insufficient credits"):
+    with pytest.raises(InsufficientResourcesError, match="Insufficient credits"):
         crafting_service.craft_item(char_id, "IcePick")

--- a/tests/application/test_event_handlers.py
+++ b/tests/application/test_event_handlers.py
@@ -1,0 +1,30 @@
+import uuid
+from unittest.mock import Mock
+
+from decker_pygame.application.event_handlers import create_event_logging_handler
+from decker_pygame.application.logging_service import LoggingService
+from decker_pygame.domain.events import PlayerCreated
+from decker_pygame.domain.ids import PlayerId
+
+
+def test_create_event_logging_handler():
+    """
+    Tests that the created handler correctly formats and logs an event.
+    """
+    # Arrange
+    mock_logging_service = Mock(spec=LoggingService)
+    handler = create_event_logging_handler(mock_logging_service)
+    player_id = PlayerId(uuid.uuid4())
+    event = PlayerCreated(player_id=player_id, name="Test", initial_health=100)
+
+    # Act
+    handler(event)
+
+    # Assert
+    mock_logging_service.log.assert_called_once()
+    # Check the arguments passed to the log method
+    pos_args, kw_args = mock_logging_service.log.call_args
+    assert pos_args[0] == "Domain Event: PlayerCreated"
+    assert kw_args["data"]["player_id"] == str(player_id)
+    assert kw_args["data"]["name"] == "Test"
+    assert "event_id" in kw_args["data"]

--- a/tests/application/test_logging_service.py
+++ b/tests/application/test_logging_service.py
@@ -1,0 +1,70 @@
+from unittest.mock import Mock
+
+from decker_pygame.application.logging_service import (
+    ConsoleLogWriter,
+    LoggingService,
+    LogWriter,
+)
+
+
+def test_logging_service_dispatches_to_writers():
+    """Tests that the service calls the write method on all registered writers."""
+    # Arrange
+    mock_writer1 = Mock(spec=LogWriter)
+    mock_writer2 = Mock(spec=LogWriter)
+    service = LoggingService(writers=[mock_writer1, mock_writer2])
+    message = "Test message"
+    data = {"key": "value"}
+
+    # Act
+    service.log(message, data)
+
+    # Assert
+    mock_writer1.write.assert_called_once_with(message, data)
+    mock_writer2.write.assert_called_once_with(message, data)
+
+
+def test_logging_service_register():
+    """Tests that the register method correctly adds a new writer."""
+    # Arrange
+    mock_writer1 = Mock(spec=LogWriter)
+    mock_writer2 = Mock(spec=LogWriter)
+    # Start with one writer
+    service = LoggingService(writers=[mock_writer1])
+
+    # Act
+    # Register a second writer
+    service.register(mock_writer2)
+
+    # Log a message to see if both are called
+    message = "Test message"
+    data = {"key": "value"}
+    service.log(message, data)
+
+    # Assert
+    mock_writer1.write.assert_called_once_with(message, data)
+    mock_writer2.write.assert_called_once_with(message, data)
+
+
+def test_logging_service_register_from_empty():
+    """Tests that the register method correctly adds a new writer."""
+    # Arrange
+    service = LoggingService(writers=[])  # Start with no writers
+    mock_writer = Mock(spec=LogWriter)
+
+    # Act
+    service.register(mock_writer)
+
+    # Assert by logging a message and checking if the new writer is called
+    service.log("test", {})
+    mock_writer.write.assert_called_once_with("test", {})
+
+
+def test_console_log_writer(capsys):
+    """Tests that the console writer prints a formatted JSON string."""
+    writer = ConsoleLogWriter()
+    writer.write("Test", {"id": 1})
+
+    captured = capsys.readouterr()
+    assert '"message": "Test"' in captured.out
+    assert '"id": 1' in captured.out

--- a/tests/application/test_player_service.py
+++ b/tests/application/test_player_service.py
@@ -2,7 +2,10 @@ import uuid
 from unittest.mock import Mock, patch
 
 from decker_pygame.application.event_dispatcher import EventDispatcher
-from decker_pygame.application.player_service import PlayerService
+from decker_pygame.application.player_service import (
+    PlayerService,
+    PlayerStatusDTO,
+)
 from decker_pygame.domain.player import Player, PlayerId
 from decker_pygame.domain.player_repository_interface import PlayerRepositoryInterface
 
@@ -56,3 +59,34 @@ def test_create_new_player():
             # 4. Check that the dispatcher was called with the player's events
             mock_dispatcher.dispatch.assert_called_once_with(mock_created_player.events)
             mock_created_player.clear_events.assert_called_once()
+
+
+def test_get_player_status():
+    """Tests retrieving player status for the UI."""
+    # Arrange
+    mock_repo = Mock(spec=PlayerRepositoryInterface)
+    player_service = PlayerService(player_repo=mock_repo, event_dispatcher=Mock())
+    player_id = PlayerId(uuid.uuid4())
+
+    mock_player = Mock(spec=Player)
+    mock_player.health = 80
+    mock_repo.get.return_value = mock_player
+
+    # Act
+    status = player_service.get_player_status(player_id)
+
+    # Assert
+    mock_repo.get.assert_called_once_with(player_id)
+    assert isinstance(status, PlayerStatusDTO)
+    assert status.current_health == 80
+    assert status.max_health == 100  # Based on current implementation
+
+
+def test_get_player_status_not_found():
+    """Tests that getting status for a non-existent player returns None."""
+    mock_repo = Mock(spec=PlayerRepositoryInterface)
+    player_service = PlayerService(player_repo=mock_repo, event_dispatcher=Mock())
+    player_id = PlayerId(uuid.uuid4())
+    mock_repo.get.return_value = None
+
+    assert player_service.get_player_status(player_id) is None

--- a/tests/presentation/components/test_alarm_bar.py
+++ b/tests/presentation/components/test_alarm_bar.py
@@ -9,7 +9,7 @@ from decker_pygame.settings import ALARM
 def alarm_bar_instance():
     """Fixture to create a default AlarmBar instance for tests."""
     pygame.init()
-    bar = AlarmBar(10, 20, 200, 20)
+    bar = AlarmBar(position=(10, 20), width=200, height=20)
     yield bar
     pygame.quit()
 
@@ -22,8 +22,8 @@ class TestAlarmBar:
         assert isinstance(bar, pygame.sprite.Sprite)
         assert bar.rect.topleft == (10, 20)
         assert bar.rect.size == (200, 20)
-        assert bar.alarm_level == 0
-        assert bar.color == ALARM.colors[0]
+        assert bar._percentage == 0.0
+        assert bar._color == ALARM.colors[0]
 
         # Check that it's initially transparent
         assert bar.image.get_at((5, 5)) == pygame.Color(0, 0, 0, 0)
@@ -34,11 +34,11 @@ class TestAlarmBar:
 
         bar.update_state(alert_level=50, is_crashing=False)
 
-        assert bar.alarm_level == 50
+        assert bar._percentage == 50.0
 
         expected_index = int(0.5 * (len(ALARM.colors) - 1))
         expected_color = ALARM.colors[expected_index]
-        assert bar.color == expected_color
+        assert bar._color == expected_color
 
         # Check rendering: pixel at 25% width should be bar color
         assert bar.image.get_at((49, 10)) == expected_color
@@ -51,8 +51,8 @@ class TestAlarmBar:
 
         bar.update_state(alert_level=75, is_crashing=True)
 
-        assert bar.alarm_level == 75
-        assert bar.color == ALARM.crash_color
+        assert bar._percentage == 75.0
+        assert bar._color == ALARM.crash_color
         assert bar.image.get_at((74, 10)) == ALARM.crash_color
 
     def test_alarm_level_clamping(self, alarm_bar_instance: AlarmBar):
@@ -60,16 +60,16 @@ class TestAlarmBar:
         bar = alarm_bar_instance
 
         bar.update_state(alert_level=150, is_crashing=False)
-        assert bar.alarm_level == 100
+        assert bar._percentage == 100.0
 
         bar.update_state(alert_level=-50, is_crashing=False)
-        assert bar.alarm_level == 0
+        assert bar._percentage == 0.0
 
     def test_alarm_bar_eq_and_hash_repr(self):
         """Tests basic object methods for the sprite."""
         pygame.init()
-        bar1 = AlarmBar(0, 0, 100, 10)
-        bar2 = AlarmBar(0, 0, 100, 10)
+        bar1 = AlarmBar(position=(0, 0), width=100, height=10)
+        bar2 = AlarmBar(position=(0, 0), width=100, height=10)
 
         assert bar1 == bar1
         assert bar1 != bar2  # Different object instances

--- a/tests/presentation/components/test_health_bar.py
+++ b/tests/presentation/components/test_health_bar.py
@@ -14,44 +14,40 @@ def pygame_context():
 
 
 @pytest.fixture
-def health_bar():
-    """Provides a HealthBar instance for testing."""
-    return HealthBar(position=(10, 10), width=100, height=10)
+def health_bar_instance() -> HealthBar:
+    """Provides a default HealthBar instance for tests."""
+    return HealthBar(position=(10, 20), width=200, height=20)
 
 
-def test_initialization(health_bar: HealthBar):
-    """Tests that the health bar initializes to a full, green state."""
-    assert health_bar.rect.topleft == (10, 10)
-    assert health_bar._health_percent == 100
-    assert health_bar._color == HEALTH.colors[0][1]  # Green
+def test_initialization(health_bar_instance: HealthBar):
+    """Tests that the health bar initializes correctly."""
+    bar = health_bar_instance
+    assert isinstance(bar, pygame.sprite.Sprite)
+    assert bar.rect.topleft == (10, 20)
+    assert bar._percentage == 100.0
+    assert bar._color == HEALTH.colors[0][1]  # Full health color
 
 
 @pytest.mark.parametrize(
     "current, maximum, expected_percent, expected_color_index",
     [
-        (100, 100, 100, 0),  # Full health -> Green
-        (40, 80, 50, 1),  # Half health -> Yellow
-        (10, 100, 10, 2),  # Low health -> Red
-        (0, 100, 0, 2),  # Zero health -> Red
-        (120, 100, 100, 0),  # Over-full health -> Green (clamped)
-        (-10, 100, 0, 2),  # Negative health -> Red (clamped)
-        (50, 0, 0, 2),  # Zero max health -> Red
+        (100, 100, 100.0, 0),  # Full health -> Green
+        (40, 100, 40.0, 1),  # Mid health -> Yellow
+        (10, 100, 10.0, 2),  # Low health -> Red
+        (0, 100, 0.0, 2),  # Zero health -> Red
+        (120, 100, 100.0, 0),  # Clamped high
+        (-10, 100, 0.0, 2),  # Clamped low
     ],
 )
 def test_update_health(
-    health_bar: HealthBar,
+    health_bar_instance: HealthBar,
     current: int,
     maximum: int,
     expected_percent: float,
     expected_color_index: int,
 ):
-    """Tests that the health bar updates its state and color correctly."""
-    health_bar.update_health(current, maximum)
-
-    assert health_bar._health_percent == pytest.approx(expected_percent)
-    assert health_bar._color == HEALTH.colors[expected_color_index][1]
-
-    # Check that the bar is drawn with the correct width
-    drawn_width = health_bar.image.get_bounding_rect().width
-    expected_width = int(100 * (expected_percent / 100))
-    assert drawn_width == expected_width
+    """Tests updating health and color based on different values."""
+    bar = health_bar_instance
+    bar.update_health(current, maximum)
+    assert bar._percentage == expected_percent
+    assert bar._color == HEALTH.colors[expected_color_index][1]

--- a/tests/presentation/test_game.py
+++ b/tests/presentation/test_game.py
@@ -6,11 +6,14 @@ import pygame
 import pytest
 
 from decker_pygame.application.crafting_service import CraftingError, CraftingService
+from decker_pygame.application.logging_service import LoggingService
 from decker_pygame.application.player_service import PlayerService
 from decker_pygame.domain.ids import CharacterId, PlayerId
 from decker_pygame.presentation.components.build_view import BuildView
+from decker_pygame.presentation.components.health_bar import HealthBar
 from decker_pygame.presentation.components.message_view import MessageView
 from decker_pygame.presentation.game import Game
+from decker_pygame.settings import GFX
 
 
 @pytest.fixture(autouse=True)
@@ -22,12 +25,13 @@ def pygame_context() -> Generator[None]:
 
 
 @pytest.fixture
-def game_with_mocks() -> Generator[tuple[Game, Mock, Mock]]:
+def game_with_mocks() -> Generator[tuple[Game, Mock, Mock, Mock]]:
     """
     Provides a fully mocked Game instance and its mocked dependencies.
     """
     mock_player_service = Mock(autospec=PlayerService)
     mock_crafting_service = Mock(autospec=CraftingService)
+    mock_logging_service = Mock(autospec=LoggingService)
     dummy_player_id = PlayerId(uuid.uuid4())
     dummy_character_id = CharacterId(uuid.uuid4())
 
@@ -41,27 +45,33 @@ def game_with_mocks() -> Generator[tuple[Game, Mock, Mock]]:
             "decker_pygame.presentation.game.load_spritesheet",
             return_value=([pygame.Surface((16, 16))], (16, 16)),
         ),
-        patch("decker_pygame.presentation.game.pygame.transform.scale"),
+        patch("decker_pygame.presentation.game.scale_icons") as mock_scale_icons,
     ):
         game = Game(
             player_service=mock_player_service,
             player_id=dummy_player_id,
             crafting_service=mock_crafting_service,
             character_id=dummy_character_id,
+            logging_service=mock_logging_service,
         )
-        yield game, mock_player_service, mock_crafting_service
+        mock_scale_icons.return_value = [pygame.Surface((32, 32))]
+        yield game, mock_player_service, mock_crafting_service, mock_logging_service
 
 
-def test_game_initialization(game_with_mocks: tuple[Game, Mock, Mock]):
+def test_game_initialization(game_with_mocks: tuple[Game, Mock, Mock, Mock]):
     """Tests that the Game class correctly stores its injected dependencies."""
-    game, mock_player_service, mock_crafting_service = game_with_mocks
+    game, mock_player_service, mock_crafting_service, mock_logging_service = (
+        game_with_mocks
+    )
 
     # The __init__ method should store the service and id
     assert game.player_service is mock_player_service
     assert game.crafting_service is mock_crafting_service
+    assert game.logging_service is mock_logging_service
     assert isinstance(game.player_id, uuid.UUID)
     assert isinstance(game.character_id, uuid.UUID)
     assert isinstance(game.message_view, MessageView)
+    assert isinstance(game.health_bar, HealthBar)
 
     pygame.display.set_mode.assert_called_once()
     pygame.display.set_caption.assert_called_once()
@@ -75,11 +85,12 @@ def test_game_load_assets_with_icons():
         patch("pygame.display.set_caption"),
         patch("pygame.time.Clock"),
         patch("decker_pygame.presentation.game.load_spritesheet") as mock_load,
-        patch("decker_pygame.presentation.game.pygame.transform.scale") as mock_scale,
+        patch("decker_pygame.presentation.game.scale_icons") as mock_scale_icons,
     ):
         # Simulate finding one icon
         mock_icon = pygame.Surface((16, 16))
         mock_load.return_value = ([mock_icon], (16, 16))
+        mock_scale_icons.return_value = [pygame.Surface((32, 32))]
 
         # We don't need a real service or ID for this test
         game = Game(
@@ -87,17 +98,58 @@ def test_game_load_assets_with_icons():
             player_id=Mock(spec=PlayerId),
             crafting_service=Mock(autospec=CraftingService),
             character_id=Mock(spec=CharacterId),
+            logging_service=Mock(autospec=LoggingService),
         )
 
         # Assert that the scaling logic was called
         mock_load.assert_called_once()
-        mock_scale.assert_called_once()
+        mock_scale_icons.assert_called_once_with(
+            [mock_icon],
+            (GFX.active_bar_image_size, GFX.active_bar_image_size),
+        )
         assert len(game.active_bar._image_list) == 1
 
 
-def test_game_run_loop_quits(game_with_mocks: tuple[Game, Mock, Mock]):
+def test_game_load_assets_no_icons():
+    """Tests that asset loading handles the case where no icons are found."""
+    # This test needs its own setup to override the fixture's mock
+    with (
+        patch("pygame.display.set_mode"),
+        patch("pygame.display.set_caption"),
+        patch("pygame.time.Clock"),
+        patch("decker_pygame.presentation.game.load_spritesheet") as mock_load,
+        patch("decker_pygame.presentation.game.scale_icons") as mock_scale_icons,
+        # We also patch ActiveBar to prevent it from raising an error on an empty list
+        patch("decker_pygame.presentation.game.ActiveBar") as mock_active_bar,
+    ):
+        # Simulate finding no icons
+        mock_load.return_value = ([], (16, 16))
+        mock_scale_icons.return_value = []
+
+        Game(
+            player_service=Mock(autospec=PlayerService),
+            player_id=Mock(spec=PlayerId),
+            crafting_service=Mock(autospec=CraftingService),
+            character_id=Mock(spec=CharacterId),
+            logging_service=Mock(autospec=LoggingService),
+        )
+
+        mock_scale_icons.assert_called_once_with(
+            [], (GFX.active_bar_image_size, GFX.active_bar_image_size)
+        )
+        mock_active_bar.assert_called_once_with(position=(0, 0), image_list=[])
+
+
+def test_game_run_loop_quits(game_with_mocks: tuple[Game, Mock, Mock, Mock]):
     """Tests that the main game loop runs, calls its methods, and can be exited."""
-    game, _, _ = game_with_mocks
+    game, mock_player_service, _, _ = game_with_mocks
+
+    # Configure mock to prevent TypeError in _update
+    from decker_pygame.application.player_service import PlayerStatusDTO
+
+    mock_player_service.get_player_status.return_value = PlayerStatusDTO(
+        current_health=100, max_health=100
+    )
 
     # side_effect makes the mock return different values on subsequent calls.
     # 1st call: no events (loop runs). 2nd call: QUIT event (loop terminates).
@@ -136,19 +188,83 @@ def test_game_run_loop_quits(game_with_mocks: tuple[Game, Mock, Mock]):
             mock_quit.assert_called_once()
 
 
-def test_game_update(game_with_mocks: tuple[Game, Mock, Mock]):
+def test_game_quits_on_q_press(game_with_mocks: tuple[Game, Mock, Mock, Mock]):
+    """Tests that pressing 'q' sets the is_running flag to False."""
+    game, _, _, _ = game_with_mocks
+    assert game.is_running is True
+
+    q_press_event = pygame.event.Event(pygame.KEYDOWN, {"key": pygame.K_q})
+
+    with patch("pygame.event.get", return_value=[q_press_event]):
+        game._handle_events()
+
+    assert game.is_running is False
+
+
+def test_game_logs_keypress_in_dev_mode(game_with_mocks: tuple[Game, Mock, Mock, Mock]):
+    """Tests that keypresses are logged when dev mode is enabled."""
+    game, _, _, mock_logging_service = game_with_mocks
+
+    with patch("decker_pygame.presentation.game.DEV_SETTINGS.enabled", True):
+        key_event = pygame.event.Event(pygame.KEYDOWN, {"key": pygame.K_a})
+        with patch("pygame.event.get", return_value=[key_event]):
+            game._handle_events()
+
+    mock_logging_service.log.assert_called_once_with("Key Press", {"key": "a"})
+
+
+def test_game_update(game_with_mocks: tuple[Game, Mock, Mock, Mock]):
     """Tests that the _update method calls update on its sprite group."""
-    game, _, _ = game_with_mocks
+    game, mock_player_service, _, _ = game_with_mocks
     game.all_sprites = Mock()
+
+    # Configure mock to prevent TypeError
+    from decker_pygame.application.player_service import PlayerStatusDTO
+
+    mock_player_service.get_player_status.return_value = PlayerStatusDTO(
+        current_health=100, max_health=100
+    )
 
     game._update()
 
     game.all_sprites.update.assert_called_once()
 
 
-def test_game_show_message(game_with_mocks: tuple[Game, Mock, Mock]):
+def test_game_update_calls_update_health(
+    game_with_mocks: tuple[Game, Mock, Mock, Mock],
+):
+    """Tests that the _update method updates the health bar."""
+    game, mock_player_service, _, _ = game_with_mocks
+    game.health_bar = Mock(spec=HealthBar)  # Replace real with mock
+
+    # Mock the DTO returned by the service
+    from decker_pygame.application.player_service import PlayerStatusDTO
+
+    dto = PlayerStatusDTO(current_health=75, max_health=100)
+    mock_player_service.get_player_status.return_value = dto
+
+    game._update()
+
+    mock_player_service.get_player_status.assert_called_once_with(game.player_id)
+    game.health_bar.update_health.assert_called_once_with(75, 100)
+
+
+def test_game_update_no_player_status(game_with_mocks: tuple[Game, Mock, Mock, Mock]):
+    """Tests that _update handles the case where the player is not found."""
+    game, mock_player_service, _, _ = game_with_mocks
+    game.health_bar = Mock(spec=HealthBar)  # Replace real with mock
+    mock_player_service.get_player_status.return_value = None
+
+    game._update()
+
+    # Ensure update_health is not called if there's no status
+    mock_player_service.get_player_status.assert_called_once_with(game.player_id)
+    game.health_bar.update_health.assert_not_called()
+
+
+def test_game_show_message(game_with_mocks: tuple[Game, Mock, Mock, Mock]):
     """Tests that the show_message method calls set_text on the message_view."""
-    game, _, _ = game_with_mocks
+    game, _, _, _ = game_with_mocks
     # Replace the real view with a mock for this test
     game.message_view = Mock(spec=MessageView)
 
@@ -157,9 +273,9 @@ def test_game_show_message(game_with_mocks: tuple[Game, Mock, Mock]):
     game.message_view.set_text.assert_called_once_with("Test message")
 
 
-def test_game_toggles_build_view(game_with_mocks: tuple[Game, Mock, Mock]):
+def test_game_toggles_build_view(game_with_mocks: tuple[Game, Mock, Mock, Mock]):
     """Tests that pressing 'b' opens and closes the build view."""
-    game, _, mock_crafting_service = game_with_mocks
+    game, _, mock_crafting_service, _ = game_with_mocks
     # Ensure the service returns schematics so the view can be created
     mock_crafting_service.get_character_schematics.return_value = [Mock()]
 
@@ -182,12 +298,34 @@ def test_game_toggles_build_view(game_with_mocks: tuple[Game, Mock, Mock]):
         game._handle_events()
         assert game.build_view is None
         # Check that the sprite was removed from the group
-        assert len(game.all_sprites) == 3  # active_bar, alarm_bar, message_view
+        assert (
+            len(game.all_sprites) == 4
+        )  # active_bar, alarm_bar, message_view, health_bar
 
 
-def test_game_build_view_event_handling(game_with_mocks: tuple[Game, Mock, Mock]):
+def test_game_toggle_build_view_no_schematics(
+    game_with_mocks: tuple[Game, Mock, Mock, Mock], capsys
+):
+    """Tests that the build view is not opened if the character has no schematics."""
+    game, _, mock_crafting_service, _ = game_with_mocks
+    # Ensure the service returns an empty list
+    mock_crafting_service.get_character_schematics.return_value = []
+
+    assert game.build_view is None
+
+    # Press 'b' to attempt to open the view
+    open_event = pygame.event.Event(pygame.KEYDOWN, {"key": pygame.K_b})
+    with patch("pygame.event.get", return_value=[open_event]):
+        game._handle_events()
+
+    # View should not be created
+    assert game.build_view is None
+    assert "No schematics known" in capsys.readouterr().out
+
+
+def test_game_build_view_event_handling(game_with_mocks: tuple[Game, Mock, Mock, Mock]):
     """Tests that the game correctly delegates events to an active build view."""
-    game, _, _ = game_with_mocks
+    game, _, _, _ = game_with_mocks
     game.build_view = Mock(spec=BuildView)  # Manually set an active view
 
     mouse_event = pygame.event.Event(pygame.MOUSEBUTTONDOWN, {"button": 1})
@@ -197,21 +335,28 @@ def test_game_build_view_event_handling(game_with_mocks: tuple[Game, Mock, Mock]
     game.build_view.handle_event.assert_called_once_with(mouse_event)
 
 
-def test_game_handle_build_click(game_with_mocks: tuple[Game, Mock, Mock]):
+def test_game_handle_build_click(game_with_mocks: tuple[Game, Mock, Mock, Mock]):
     """Tests the callback function that handles build clicks."""
-    game, _, mock_crafting_service = game_with_mocks
+    game, _, mock_crafting_service, _ = game_with_mocks
     schematic_name = "TestSchematic"
 
-    # Test success case
-    game._handle_build_click(schematic_name)
-    mock_crafting_service.craft_item.assert_called_once_with(
-        game.character_id, schematic_name
-    )
+    # Spy on the show_message method to verify it's called
+    with patch.object(game, "show_message") as spy_show_message:
+        # Test success case
+        game._handle_build_click(schematic_name)
+        mock_crafting_service.craft_item.assert_called_once_with(
+            game.character_id, schematic_name
+        )
+        spy_show_message.assert_called_once_with(
+            f"Successfully crafted {schematic_name}!"
+        )
 
-    # Test failure case
-    mock_crafting_service.craft_item.reset_mock()
-    mock_crafting_service.craft_item.side_effect = CraftingError("Test Error")
-    game._handle_build_click(schematic_name)
-    mock_crafting_service.craft_item.assert_called_once_with(
-        game.character_id, schematic_name
-    )
+        # Test failure case
+        mock_crafting_service.craft_item.reset_mock()
+        spy_show_message.reset_mock()
+        mock_crafting_service.craft_item.side_effect = CraftingError("Test Error")
+        game._handle_build_click(schematic_name)
+        mock_crafting_service.craft_item.assert_called_once_with(
+            game.character_id, schematic_name
+        )
+        spy_show_message.assert_called_once_with("Crafting failed: Test Error")

--- a/tests/presentation/test_utils.py
+++ b/tests/presentation/test_utils.py
@@ -1,52 +1,72 @@
+from unittest.mock import Mock, patch
+
 import pygame
 import pytest
 
-from decker_pygame.presentation.utils import get_and_ensure_rect
+from decker_pygame.presentation.utils import get_and_ensure_rect, scale_icons
+
+# --- Tests for scale_icons ---
 
 
-@pytest.fixture(autouse=True)
-def pygame_context():
-    """Fixture to automatically initialize and quit Pygame for each test."""
-    pygame.init()
-    yield
-    pygame.quit()
+def test_scale_icons():
+    """
+    Tests that the scale_icons utility correctly calls pygame.transform.scale
+    for each icon in the list.
+    """
+    # Arrange
+    icons = [pygame.Surface((16, 16)), pygame.Surface((16, 16))]
+    target_size = (32, 32)
+
+    with patch("decker_pygame.presentation.utils.pygame.transform.scale") as mock_scale:
+        mock_scale.return_value = Mock(spec=pygame.Surface)
+
+        # Act
+        result = scale_icons(icons, target_size)
+
+        # Assert
+        assert mock_scale.call_count == 2
+        mock_scale.assert_called_with(icons[1], target_size)
+        assert len(result) == 2
 
 
-def test_get_rect_from_existing_rect():
+def test_scale_icons_with_empty_list():
+    """
+    Tests that scale_icons handles an empty list gracefully without calling
+    the scaling function. This covers the previously missed branch.
+    """
+    with patch("decker_pygame.presentation.utils.pygame.transform.scale") as mock_scale:
+        result = scale_icons([], (32, 32))
+
+        assert result == []
+        mock_scale.assert_not_called()
+
+
+# --- Tests for get_and_ensure_rect ---
+
+
+def test_get_and_ensure_rect_with_existing_rect():
     """Tests that the function returns an existing rect."""
     sprite = pygame.sprite.Sprite()
-    expected_rect = pygame.Rect(10, 20, 30, 40)
+    expected_rect = pygame.Rect(10, 10, 20, 20)
     sprite.rect = expected_rect
 
     rect = get_and_ensure_rect(sprite)
     assert rect is expected_rect
 
 
-def test_get_rect_from_image():
-    """Tests that the function creates and returns a rect from a sprite's image."""
+def test_get_and_ensure_rect_creates_from_image():
+    """Tests that the function creates a rect from a sprite's image."""
     sprite = pygame.sprite.Sprite()
-    sprite.image = pygame.Surface((50, 60))
+    sprite.image = pygame.Surface((50, 50))
 
-    assert not hasattr(sprite, "rect") or sprite.rect is None
     rect = get_and_ensure_rect(sprite)
     assert hasattr(sprite, "rect")
-    assert sprite.rect is rect
-    assert rect.size == (50, 60)
+    assert rect.size == (50, 50)
+    assert rect is sprite.rect
 
 
-def test_get_rect_fails_for_invalid_sprite():
-    """Tests that the function raises an error for a sprite with no rect or image."""
-    sprite = pygame.sprite.Sprite()  # A bare sprite
-
-    with pytest.raises(AttributeError, match="Cannot get rect for sprite"):
+def test_get_and_ensure_rect_raises_error():
+    """Tests that the function raises an error if no rect or image exists."""
+    sprite = pygame.sprite.Sprite()  # Has no .rect or .image
+    with pytest.raises(AttributeError, match="Cannot get rect"):
         get_and_ensure_rect(sprite)
-
-
-def test_get_rect_handles_none_attributes():
-    """Tests that the function handles cases where attributes are explicitly None."""
-    sprite_with_none_rect = pygame.sprite.Sprite()
-    sprite_with_none_rect.rect = None
-    sprite_with_none_rect.image = pygame.Surface((10, 10))
-
-    rect = get_and_ensure_rect(sprite_with_none_rect)
-    assert rect.size == (10, 10)


### PR DESCRIPTION
This commit introduces several quality-of-life improvements and testing enhancements.

- Adds 'q' as a key to quit the game for more intuitive controls.
- Implements a dev-mode-only logger for keypresses, separating debug information from domain event logs.
- Refactors icon scaling logic into a reusable utility function, cleaning up the main Game class.
- Fixes a series of subtle test failures by improving mock configurations, correcting assertions, and resolving type-checking errors with decorators.