### PR TITLE
refactor(presentation): Remove debug elements and streamline input

### DIFF
--- a/docs/porting_items.md
+++ b/docs/porting_items.md
@@ -159,9 +159,9 @@ Top-level application logic, main loop, graphics, sound, and file handling. Thes
     -   **`Decker.ini`**: The asset configuration will be moved from the INI format to a new `data/assets.json` file.
     -   **Action:** Create an `AssetService` responsible for loading all Pygame surfaces and sounds based on the new JSON configuration. This will centralize asset management.
 
--   **Task G.2: Port Core Gameplay Entities (Status: In Progress)**
+-   **Task G.2: Port Core Gameplay Entities (Status: Complete)**
     -   **`DSFile.cpp/h`**: This is a critical domain entity representing files within a system's datastore.
-    -   **Action:** Port `CDSFile` to a new `DSFile` domain model in `src/decker_pygame/domain/ds_file.py`. The domain model, repository interface, and persistence layer (`JsonFileDSFileRepository`) are now defined. This is a prerequisite for implementing the matrix run gameplay loop.
+    -   **Action:** Ported `CDSFile` to a new `DSFile` domain model. A full vertical slice was implemented, including the domain model, repository interface, in-memory and JSON repositories, an application service, and integration into the presentation layer for debugging.
 
 -   **Task G.3: Port Core Engine Logic (Status: In Progress)**
     -   **`Decker.cpp/h`**: The application lifecycle logic (initialization, main loop, shutdown) is being ported to `src/decker_pygame/presentation/main.py` and `src/decker_pygame/presentation/game.py`.

--- a/src/decker_pygame/presentation/game.py
+++ b/src/decker_pygame/presentation/game.py
@@ -34,8 +34,6 @@ from decker_pygame.ports.service_interfaces import (
     ShopServiceInterface,
 )
 from decker_pygame.presentation.asset_service import AssetService
-from decker_pygame.presentation.components.active_bar import ActiveBar
-from decker_pygame.presentation.components.alarm_bar import AlarmBar
 from decker_pygame.presentation.components.build_view import BuildView
 from decker_pygame.presentation.components.char_data_view import CharDataView
 from decker_pygame.presentation.components.contract_data_view import ContractDataView
@@ -43,7 +41,6 @@ from decker_pygame.presentation.components.contract_list_view import ContractLis
 from decker_pygame.presentation.components.deck_view import DeckView
 from decker_pygame.presentation.components.entry_view import EntryView
 from decker_pygame.presentation.components.file_access_view import FileAccessView
-from decker_pygame.presentation.components.health_bar import HealthBar
 from decker_pygame.presentation.components.home_view import HomeView
 from decker_pygame.presentation.components.ice_data_view import IceDataView
 from decker_pygame.presentation.components.intro_view import IntroView
@@ -68,13 +65,7 @@ from decker_pygame.presentation.components.transfer_view import TransferView
 from decker_pygame.presentation.debug_actions import DebugActions
 from decker_pygame.presentation.input_handler import PygameInputHandler
 from decker_pygame.presentation.protocols import Eventful
-from decker_pygame.presentation.utils import scale_icons
-from decker_pygame.settings import (
-    BLACK,
-    FPS,
-    GFX,
-    UI_FACE,
-)
+from decker_pygame.settings import BLACK, FPS, UI_FACE
 
 V = TypeVar("V", bound=pygame.sprite.Sprite)
 
@@ -107,10 +98,6 @@ class Game:
         clock (pygame.time.Clock): The game clock for managing FPS.
         is_running (bool): Flag to control the main game loop.
         all_sprites (pygame.sprite.Group[pygame.sprite.Sprite]): Group for all sprites.
-        asset_service (AssetService): The service for loading game assets.
-        active_bar (ActiveBar): The UI component for active programs.
-        alarm_bar (AlarmBar): The UI component for the system alarm level.
-        health_bar (HealthBar): The UI component for player health.
         player_service (PlayerServiceInterface): Service for player operations.
         character_service (CharacterServiceInterface): Service for character operations.
         contract_service (ContractServiceInterface): Service for contract operations.
@@ -122,6 +109,7 @@ class Game:
         settings_service (SettingsServiceInterface): The service for game settings.
         project_service (ProjectServiceInterface): The service for R&D projects.
         player_id (PlayerId): The ID of the current player.
+        asset_service (AssetService): The service for loading game assets.
         character_id (CharacterId): The ID of the current character.
         logging_service (LoggingServiceInterface): Service for logging.
         message_view (MessageView): The UI component for displaying messages.
@@ -158,10 +146,6 @@ class Game:
     clock: pygame.time.Clock
     is_running: bool
     all_sprites: pygame.sprite.Group[pygame.sprite.Sprite]
-    asset_service: AssetService
-    active_bar: ActiveBar
-    alarm_bar: AlarmBar
-    health_bar: HealthBar
     player_service: PlayerServiceInterface
     character_service: CharacterServiceInterface
     contract_service: ContractServiceInterface
@@ -173,6 +157,7 @@ class Game:
     settings_service: SettingsServiceInterface
     project_service: ProjectServiceInterface
     player_id: PlayerId
+    asset_service: AssetService
     character_id: CharacterId
     logging_service: LoggingServiceInterface
     message_view: MessageView
@@ -242,36 +227,10 @@ class Game:
             self, logging_service, self.debug_actions
         )
 
-        self._load_assets()
-        self.toggle_intro_view()
-
-    def _load_assets(self) -> None:
-        """Load game assets (images, sounds, etc).
-
-        Returns:
-            None:
-        """
-        # Get pre-loaded icons from the asset service
-        program_icons = self.asset_service.get_spritesheet("program_icons")
-
-        # Scale the icons up to the size required by the UI components
-        target_size = (GFX.active_bar_image_size, GFX.active_bar_image_size)
-        scaled_program_icons = scale_icons(program_icons, target_size)
-
-        self.active_bar = ActiveBar(position=(0, 0), image_list=scaled_program_icons)
-        self.all_sprites.add(self.active_bar)
-
-        # Position from DeckerSource_1_12/MatrixView.cpp
-        self.alarm_bar = AlarmBar(position=(206, 342), width=200, height=50)
-        self.all_sprites.add(self.alarm_bar)
-
-        self.health_bar = HealthBar(position=(10, 342), width=180, height=50)
-        self.all_sprites.add(self.health_bar)
-
         self.message_view = MessageView(
             position=(10, 600), size=(400, 150), background_color=UI_FACE
         )
-        self.all_sprites.add(self.message_view)
+        self.toggle_intro_view()
 
     def _toggle_view(
         self,
@@ -882,13 +841,6 @@ class Game:
         Returns:
             None:
         """
-        player_status = self.player_service.get_player_status(self.player_id)
-        if player_status:
-            self.health_bar.update_health(
-                player_status.current_health, player_status.max_health
-            )
-            # self.alarm_bar.update_state(player.alert_level, player.is_crashing)
-
         self.all_sprites.update()
 
     def run(self) -> None:

--- a/src/decker_pygame/presentation/input_handler.py
+++ b/src/decker_pygame/presentation/input_handler.py
@@ -31,19 +31,11 @@ class PygameInputHandler:
         self._logging_service = logging_service
         self._debug_actions = debug_actions
         self._key_map = {
+            # Navigation
             pygame.K_h: self._game.toggle_home_view,
-            pygame.K_b: self._game.toggle_build_view,
-            pygame.K_c: self._game.toggle_char_data_view,
-            pygame.K_t: self._game.toggle_transfer_view,
-            pygame.K_l: self._game.toggle_contract_list_view,
-            pygame.K_d: self._game.toggle_contract_data_view,
-            pygame.K_p: self._game.toggle_deck_view,
+            # Debug
             pygame.K_m: self._debug_actions.get_ds_file,
-            pygame.K_f: lambda: self._game.show_file_access_view("corp_server_1"),
-            pygame.K_e: lambda: self._game.toggle_entry_view("corp_server_1"),
-            pygame.K_o: self._game.toggle_options_view,
-            pygame.K_u: self._game.toggle_sound_edit_view,
-            pygame.K_r: self._game.toggle_new_project_view,
+            # System
             pygame.K_q: self._game.quit,
         }
 

--- a/tests/presentation/test_input_handler.py
+++ b/tests/presentation/test_input_handler.py
@@ -47,15 +47,6 @@ def test_handle_quit_event(
     "key, method_name",
     [
         (pygame.K_h, "toggle_home_view"),
-        (pygame.K_t, "toggle_transfer_view"),
-        (pygame.K_b, "toggle_build_view"),
-        (pygame.K_c, "toggle_char_data_view"),
-        (pygame.K_l, "toggle_contract_list_view"),
-        (pygame.K_d, "toggle_contract_data_view"),
-        (pygame.K_p, "toggle_deck_view"),
-        (pygame.K_o, "toggle_options_view"),
-        (pygame.K_u, "toggle_sound_edit_view"),
-        (pygame.K_r, "toggle_new_project_view"),
         (pygame.K_q, "quit"),
     ],
 )


### PR DESCRIPTION
This commit cleans up the codebase in preparation for implementing the `MatrixRunView`. It removes temporary debug elements and simplifies the input handling.

- Removes HUD elements (`ActiveBar`, `AlarmBar`, `HealthBar`) from the `Game` class, as these are now specific to the `MatrixRunView`.
- Simplifies the `PygameInputHandler` by removing temporary hotkeys.
- Updates `test_game.py` to reflect the removal of HUD elements, adjusting sprite counts and removing obsolete tests.
- Updates `test_input_handler.py` to align with the streamlined keybindings.