### PR TITLE
refactor(presentation): Implement state machine and migrate view logic

### DIFF
--- a/docs/porting_items.md
+++ b/docs/porting_items.md
@@ -203,25 +203,16 @@ Top-level application logic, main loop, graphics, sound, and file handling. Thes
 This group focuses on improving the core architecture of the presentation layer to enhance maintainability and reduce complexity.
 
 **Phase 1: Implement Game State Machine**
--   **Task H.1:** Define `GameState` enum and `BaseState` protocol. (Status: Complete)
--   **Task H.2:** Refactor `Game` class to manage a `current_state` and delegate main loop calls. (Status: In Progress)
--   **Task H.2.1** update Game imports/attributes (Status: Complete)
--   **Task H.2.2** implement set_state  (Status: Complete)
--   **Task H.2.3** modify Game.__init__  (Status: Complete)
--   **Task H.2.4** refactor Game.run()  (Status: Complete)
--   **Task H.2.5** remove _update  (Status: Complete)
--   **Task H.2.6** Relocate `toggle_*` functions to appropriate states or a dedicated view manager. (Status: To Do)
-    -   **Task H.2.6.A:** Create a `ViewManager` class to encapsulate the `_toggle_view` logic and the `_modal_stack`. (Status: To Do)
-    -   **Task H.2.6.B:** Refactor `Game` to use the `ViewManager` for all view toggling. (Status: Complete)
-    -   **Task H.2.6.C:** Migrate `toggle_intro_view` logic from `Game` to `IntroState`. (Status: Complete)
-    -   **Task H.2.6.D:** Migrate `toggle_new_char_view` logic from `Game` to `NewCharState`. (Status: Complete)
-    -   **Task H.2.6.E:** Migrate `toggle_home_view` logic from `Game` to `HomeState`. (Status: Complete)
-    -   **Task H.2.6.F:** Migrate `toggle_matrix_run_view` logic from `Game` to `MatrixRunState`. (Status: Complete)
-    -   **Task H.2.6.G:** Refactor remaining `toggle_*_view` calls in `Game` to use the `ViewManager`. (Status: To Do)
-    -   **Task H.2.6.H:** Remove redundant `toggle_*_view` methods from `Game` once their logic has been fully migrated. (Status: To Do)
--   **Task H.3:** Create `IntroState` and `NewCharState` by migrating logic from `Game`. (Status: To Do)
--   **Task H.4:** Create `HomeState` to act as the central hub for the main game. (Status: To Do)
--   **Task H.5:** Refactor `Game`'s modal view management (`_toggle_view`) to be called by the active state. (Status: To Do)
+-   **Task H.1:** Implement the core Game State Machine. (Status: Complete)
+    -   Defined `GameState` enum and `BaseState` protocol.
+    -   Refactored `Game` class to manage `current_state` and delegate main loop calls.
+    -   Created a `ViewManager` to handle modal view logic.
+    -   Created concrete state classes (`IntroState`, `NewCharState`, `HomeState`, `MatrixRunState`).
+    -   Migrated view management logic from `Game` into the corresponding state classes.
+
+**Phase 2: Decouple Modal Views**
+-   **Task H.2:** Refactor secondary (modal-only) views to be managed by the active state. (Status: To Do)
+    -   **Example:** The `HomeState` should be responsible for toggling the `ShopView`, `DeckView`, etc., not the `Game` class.
 -   **Task H.6:** Refactor `test_game.py` into smaller, state-focused test files. (Status: To Do)
 -   **Task H.7:** Document the Game State Machine architecture in `docs/architecture/game_state_machine.md`. (Status: To Do)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,5 +10,7 @@ import pytest
 def pygame_context() -> Generator[None]:
     """Fixture to automatically initialize and quit Pygame for each test."""
     pygame.init()
+    # Many pygame operations require a display to be set.
+    pygame.display.set_mode((1, 1))
     yield
     pygame.quit()

--- a/tests/presentation/test_asset_service.py
+++ b/tests/presentation/test_asset_service.py
@@ -1,6 +1,7 @@
 """Tests for the AssetService."""
 
 import json
+from collections.abc import Generator
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
@@ -11,17 +12,8 @@ import pytest
 from decker_pygame.presentation.asset_service import AssetService
 
 
-@pytest.fixture(autouse=True)
-def pygame_init_fixture():
-    """Fixture to initialize pygame for each test."""
-    pygame.init()
-    pygame.display.set_mode((1, 1))
-    yield
-    pygame.quit()
-
-
 @pytest.fixture
-def temp_asset_dir() -> str:
+def temp_asset_dir() -> Generator[str]:
     """Create a temporary directory for test asset files."""
     with TemporaryDirectory() as tmpdir:
         yield tmpdir


### PR DESCRIPTION
This commit completes a major architectural refactoring by implementing a full Game State Machine and making the primary game states (`IntroState`, `NewCharState`, `HomeState`, `MatrixRunState`) responsible for managing their own UI views.

This work fulfills Phase 1 of the Group H architectural refactoring.

Key changes include:
- **State Machine:** The `Game` class now manages a `current_state` and delegates its `update` and `draw` calls, simplifying the main loop.
- **View Manager:** A `ViewManager` class was introduced to handle the low-level logic of toggling views and managing the modal stack.
- **State-Owned Views:** The responsibility for creating and toggling the primary views (`IntroView`, `HomeView`, etc.) has been moved from the `Game` class into the `on_enter` and `on_exit` methods of their corresponding state classes.
- **Input Handling:** The `InputHandler` and `DebugActions` were updated to trigger state transitions (`game.set_state()`) instead of calling view-specific toggle methods on the `Game` object.
- **Test Refactoring:** The test suite was significantly updated to remove obsolete tests and add new, specific lifecycle tests for each state, ensuring 100% coverage of the new architecture.
- **Bug Fixes:** Resolved a `Segmentation fault` in the test suite caused by conflicting Pygame initialization fixtures.

This change dramatically cleans up the `Game` class, decouples the core components, and makes the overall application flow much easier to follow and maintain.